### PR TITLE
Fix/tags bug

### DIFF
--- a/src/scripts.js
+++ b/src/scripts.js
@@ -120,19 +120,18 @@ function displayFavoritesView() {
   hide(allRecipesSection);
   hide(weeklyRecipesSection);
   show(favoriteRecipesSection);
-
+  clearTags()
   checkFavoriteRecipes();
 }
 
 function checkFavoriteRecipes() {
-  if (user.favoriteRecipes.length && !tags.length) {
+  if (user.favoriteRecipes.length) {
     hide(noFavoritesMessage);
     show(favoriteRecipesContainer);
+    hide(favoriteTaggedRecipesContainer)
 
     addTagsGlide();
     renderRecipeCards(favoriteRecipesContainer, user.favoriteRecipes);
-  } else if (user.favoriteRecipes.length && tags.length) {
-    hide(noFavoritesMessage);
   } else {
     hide(favoriteRecipesContainer);
     show(noFavoritesMessage);
@@ -204,7 +203,8 @@ function displayHomeView() {
   hide(displayedSearchResults);
   hide(favoriteRecipesSection);
   show(homeViewSection);
-
+  hide(taggedRecipesContainer)
+  clearTags()
   addStyling(singleRecipeView, 'single-recipe-view');
   addStyling(allRecipesSection, 'all-recipes-view__recipes-container');
   removeStyling(singleRecipeView, 'single-recipe-view-alt');
@@ -470,4 +470,10 @@ function addStyling(element, className) {
 
 function removeStyling(element, className) {
   element.classList.remove(className);
+}
+
+function clearTags() {
+  const selectedTags = document.querySelectorAll('.tag-selected')
+  tags = [];
+  selectedTags.forEach(tag => tag.classList.toggle('tag-selected'));
 }


### PR DESCRIPTION
**What (if any) features are you implementing?**
- NA
- Fixed tags bug (whenever tags in the home view or favorites view were selected, they would affect each other). I created a clearTags function that makes sure all tags get unselected when clicking either the home view or the favorites view. This clears our tags search whenever we enter each of those views. 

**What (if anything) did you refactor?**
- NA

**Were there any issues that arose?**
- Please let me know what you think of the tags getting deselected. It was the only way I could think of to ensure the tags selections wouldn't interact, but I am open to any suggestions.

**Any other comments, questions, or concerns?**
- NA

**Is there anything you need from your team?**
- Please review and test to make sure I didn't miss anything. Thank you!
